### PR TITLE
 Add d3a-api-client cli alias for backward compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
     entry_points={
         "console_scripts": [
             "gsy-e-sdk = gsy_e_sdk.cli:main",
+            "d3a-api-client = gsy_e_sdk.cli:main",
         ]
     },
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,10 @@ commands =
 	coverage combine
 	coverage report
 
+[flake8]
+max-line-length = 99
+exclude = .tox,.cache,.pytest_cache
+
 [testenv:integrationtests]
 basepython = python3.8
 deps =


### PR DESCRIPTION
+ Add flake8 configurations in the `tox.ini` module to extend the max-line-length config to 99