### PR TITLE
Fix the name of the folder created for tests

### DIFF
--- a/integration_tests/build_test_containers.sh
+++ b/integration_tests/build_test_containers.sh
@@ -5,8 +5,8 @@ set -e
 GSY_E_IMAGE_TAG="gsy-e-tests"
 
 if [[ "$(docker images -q ${GSY_E_IMAGE_TAG} 2> /dev/null)" == "" ]]; then
-  echo "Building d3a image ..." && \
-  rm -rf tests/d3a && \
+  echo "Building GSy-e image ..." && \
+  rm -rf tests/gsy-e && \
   cd tests/ && \
   git clone https://github.com/gridsingularity/gsy-e.git && \
   cd gsy-e && \


### PR DESCRIPTION
Integration tests were trying to delete a folder that was not being created anymore (because of the rebranding).