### PR TITLE
D3ASIM-3553: Rename area_uuid parameters to asset_uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,11 +230,11 @@ The following commands can be issued as batch commands (refer to [How to send ba
 
 - Send an energy bid with price in cents:
     ```python
-    bid_energy(area_uuid, energy, price_cents, replace_existing, attributes, requirements)
+    bid_energy(asset_uuid, energy, price_cents, replace_existing, attributes, requirements)
     ```
 - Send an energy bid with energy rate in cents/kWh:
     ```python
-    bid_energy_rate(area_uuid, energy, rate_cents_per_kWh, replace_existing, attributes, requirements)
+    bid_energy_rate(asset_uuid, energy, rate_cents_per_kWh, replace_existing, attributes, requirements)
     ```
 - Change grid fees using a percentage value:
     ```python
@@ -246,23 +246,23 @@ The following commands can be issued as batch commands (refer to [How to send ba
     ```
 - Delete offer using its ID:
     ```python
-    delete_offer(area_uuid, offer_id)
+    delete_offer(asset_uuid, offer_id)
     ```
 - Delete bid using its ID:
     ```python
-    delete_bid(area_uuid, bid_id)
+    delete_bid(asset_uuid, bid_id)
     ```
 - Get asset info (returns demanded energy for Load assets and available energy for PVs):
     ```python
-    asset_info(area_uuid)
+    asset_info(asset_uuid)
     ```
 - List all posted offers:
     ```python
-    list_offers(area_uuid)
+    list_offers(asset_uuid)
     ```
 - Lists all posted bids:
     ```python
-    list_bids(area_uuid)
+    list_bids(asset_uuid)
     ```
 - Retrieve market DSO statistics:
     ```python
@@ -270,11 +270,11 @@ The following commands can be issued as batch commands (refer to [How to send ba
     ```
 - Send an energy offer with price in cents:
     ```python
-    offer_energy(area_uuid, energy, price_cents, replace_existing, attributes, requirements)
+    offer_energy(asset_uuid, energy, price_cents, replace_existing, attributes, requirements)
     ```
 - Send an energy offer with energy rate in cents/kWh:
     ```python
-    offer_energy_rate(area_uuid, energy, rate_cents_per_kWh, replace_existing, attributes, requirements)
+    offer_energy_rate(asset_uuid, energy, rate_cents_per_kWh, replace_existing, attributes, requirements)
     ```
 ---
 ### Attributes and requirements

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ In the following commands for the connection via the REST API are marked with `R
 
 Installation of gsy-e-sdk using pip:
 
-```
+```bash
 pip install git+https://github.com/gridsingularity/gsy-e-sdk.git
 ```
 ---
@@ -50,7 +50,7 @@ pip install git+https://github.com/gridsingularity/gsy-e-sdk.git
 
 ### Interacting via CLI
 In order to get help, please run:
-```
+```bash
 gsy-e-sdk run --help
 ```
 The following parameters can be set via the CLI:
@@ -69,16 +69,16 @@ The following parameters can be set via the CLI:
 
 #### Examples
 - For local testing of the API client:
-  ```
+  ```bash
   gsy-e-sdk --log-level ERROR run --setup test_redis_aggregator --run-on-redis
   ```
 - For testing your api client script on remote server hosting GSy Exchange's collaboration/CNs.
     - If user's client script resides on `gsy_e_sdk/setups`
-    ```
+    ```bash
     gsy-e-sdk run -u <username> -p <password> --setup test_create_aggregator --simulation-config-path <your-downloaded-simulation-config-file-path>
     ```
     - If user's client script resides on a different directory, then its path needs to be set via `--base-setup-path`
-    ```
+    ```bash
     gsy-e-sdk run -u <username> -p <password> --base-setup-path <absolute/relative-path-to-your-client-script> --setup <name-of-your-script> --simulation-config-path <your-downloaded-simulation-config-file-path>
     ```
 
@@ -101,23 +101,23 @@ by overriding the corresponding methods.
 The constructor of the API class can connect and register automatically to a running collaboration:
 - `REST`
   (here the asset uuid has to be obtained first)
-    ```
+    ```python
     asset_uuid = get_area_uuid_from_area_name_and_collaboration_id(
                   <simulation_id>, <asset_name>, <domain_name>
                   )
     asset_client = RestAssetClient(asset_uuid, autoregister=True)
     ```
 - `LOCAL`
-    ```
-    asset_client = RedisClient(<slugified-asset-name>, autoregister=True)
+    ```python
+    asset_client = RedisAssetClient(<asset-uuid>, autoregister=True)
     ```
 
 Otherwise one can connect manually:
-```
+```python
 asset_client.register()
 ```
 To disconnect/unregistering, the following command is available:
-```
+```python
 asset_client.unregister()
 ```
 
@@ -127,14 +127,14 @@ asset_client.unregister()
 #### How to create a connection to a Market
 - `REST`
     (here the market uuid has to be obtained first)
-    ```
+    ```python
     market_uuid = get_area_uuid_from_area_name_and_collaboration_id(
                   <simulation_id>, <market_name>, <domain_name>
                   )
     market_client = RestMarketClient(market_uuid, autoregister=True)
     ```
 - `LOCAL`
-    ```
+    ```python
     market_client = RedisMarketClient(<market_name>, autoregister=True)
     ```
 
@@ -146,7 +146,7 @@ commands in order to react to an event simultaneously for each owned asset.
 #### How to create an Aggregator
 
 - `REST`
-    ```
+    ```python
     aggregator = Aggregator(
             simulation_id=<simulation_id>,
             domain_name=<domain_name>,
@@ -155,14 +155,13 @@ commands in order to react to an event simultaneously for each owned asset.
             )
     ```
 - `LOCAL`
-    ```
+    ```python
     aggregator = AutoAggregator(<aggregator_name>)
     ```
 
 #### How to list your aggregators
 
 To list your aggregators, its configuration id and the registered assets, you should:
-```python
 ```python
 from gsy_e_sdk.utils import get_aggregators_list
 my_aggregators = get_aggregators_list(domain_name="Domain Name")
@@ -210,17 +209,17 @@ Commands to all or individual connected assets or markets can be sent in one bat
 All asset or market specific functions can be sent via commands that are
 accumulated and added to buffer.
 
-```
+```python
 aggregator.add_to_batch_commands.bid_energy(<asset_uuid>, <energy>, <price_cents>)
 ```
 These also can be chained as follow:
-```
+```python
 aggregator.add_to_batch_commands.bid_energy(<asset_uuid>, <energy>, <price_cents>)\
                                 .offer_energy(<asset_uuid>, <energy>, <price_cents>)\
                                 .asset_info(<asset_uuid>)
 ```
 Finally, the batch commands are sent to the GSy Exchange via the following command:
-```
+```python
 aggregator.execute_batch_command()
 ```
 

--- a/README.md
+++ b/README.md
@@ -258,11 +258,11 @@ The following commands can be issued as batch commands (refer to [How to send ba
     ```
 - List all posted offers:
     ```python
-    list_offers(asset_uuid)
+    list_offers(area_uuid)
     ```
 - Lists all posted bids:
     ```python
-    list_bids(asset_uuid)
+    list_bids(area_uuid)
     ```
 - Retrieve market DSO statistics:
     ```python

--- a/gsy_e_sdk/commands.py
+++ b/gsy_e_sdk/commands.py
@@ -82,13 +82,13 @@ class ClientCommandBuffer:
         return self._add_to_buffer(asset_uuid, Commands.DELETE_BID,
                                    {"bid_id": bid_id, "time_slot": time_slot})
 
-    def list_offers(self, asset_uuid, time_slot: str = None):
+    def list_offers(self, area_uuid, time_slot: str = None):
         """Add a command to list offers made by a specific asset in the given time slot."""
-        return self._add_to_buffer(asset_uuid, Commands.LIST_OFFERS, {"time_slot": time_slot})
+        return self._add_to_buffer(area_uuid, Commands.LIST_OFFERS, {"time_slot": time_slot})
 
-    def list_bids(self, asset_uuid, time_slot: str = None):
+    def list_bids(self, area_uuid, time_slot: str = None):
         """Add a command to list bids made by a specific asset in the given time slot."""
-        return self._add_to_buffer(asset_uuid, Commands.LIST_BIDS, {"time_slot": time_slot})
+        return self._add_to_buffer(area_uuid, Commands.LIST_BIDS, {"time_slot": time_slot})
 
     def device_info(self, area_uuid):
         """Retrieve information about the asset identified by the given UUID.

--- a/gsy_e_sdk/commands.py
+++ b/gsy_e_sdk/commands.py
@@ -7,6 +7,7 @@ from tabulate import tabulate
 
 from gsy_e_sdk.enums import Commands, command_enum_to_command_name
 
+
 # pylint: disable=too-many-arguments
 class ClientCommandBuffer:
     """Buffer used to keep in memory the batch commands until they're submitted to the server."""
@@ -83,11 +84,11 @@ class ClientCommandBuffer:
                                    {"bid_id": bid_id, "time_slot": time_slot})
 
     def list_offers(self, area_uuid, time_slot: str = None):
-        """Add a command to list offers made by a specific asset in the given time slot."""
+        """Add a command to list offers made on the specified area in the given time slot."""
         return self._add_to_buffer(area_uuid, Commands.LIST_OFFERS, {"time_slot": time_slot})
 
     def list_bids(self, area_uuid, time_slot: str = None):
-        """Add a command to list bids made by a specific asset in the given time slot."""
+        """Add a command to list bids made on the specified area in the given time slot."""
         return self._add_to_buffer(area_uuid, Commands.LIST_BIDS, {"time_slot": time_slot})
 
     def device_info(self, area_uuid):

--- a/gsy_e_sdk/commands.py
+++ b/gsy_e_sdk/commands.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import logging
 from typing import Dict, List
 
@@ -5,77 +7,88 @@ from tabulate import tabulate
 
 from gsy_e_sdk.enums import Commands, command_enum_to_command_name
 
-
+# pylint: disable=too-many-arguments
 class ClientCommandBuffer:
-
+    """Buffer used to keep in memory the batch commands until they're submitted to the server."""
     def __init__(self, ):
         self._commands_buffer = []
 
     @property
     def buffer_length(self):
+        """Return the number of commands added to the buffer up to this moment."""
         return len(self._commands_buffer)
 
     def offer_energy(
-            self, area_uuid: str, energy: float, price: float, replace_existing: bool = True,
+            self, asset_uuid: str, energy: float, price: float, replace_existing: bool = True,
             attributes: Dict = None, requirements: List[Dict] = None, time_slot: str = None):
-
+        """Add a command to issue an offer with the given price and additional parameters."""
         return self._add_to_buffer(
-            area_uuid,
+            asset_uuid,
             Commands.OFFER,
             {"energy": energy, "price": price, "replace_existing": replace_existing,
              "attributes": attributes, "requirements": requirements, "time_slot": time_slot})
 
     def offer_energy_rate(
-            self, area_uuid: str, energy: float, rate: float, replace_existing: bool = True,
+            self, asset_uuid: str, energy: float, rate: float, replace_existing: bool = True,
             attributes: Dict = None, requirements: List[Dict] = None, time_slot: str = None):
-
+        """Add a command to issue an offer with the given energy rate and additional parameters."""
         return self._add_to_buffer(
-            area_uuid,
+            asset_uuid,
             Commands.OFFER,
             {"energy": energy, "price": rate * energy, "replace_existing": replace_existing,
              "attributes": attributes, "requirements": requirements, "time_slot": time_slot})
 
+    # pylint: disable=unused-argument
+    # pylint: disable=no-self-use
     def update_offer(self, *args, **kwargs):
+        """Add a command to update an offer."""
         logging.warning("update_offer is deprecated,"
                         " use offer_energy with replace_existing=True instead.")
 
     def bid_energy(
-            self, area_uuid: str, energy: float, price: float, replace_existing: bool = True,
+            self, asset_uuid: str, energy: float, price: float, replace_existing: bool = True,
             attributes: Dict = None, requirements: List[Dict] = None, time_slot: str = None):
-
+        """Add a command to issue a bid with the given price and additional parameters."""
         return self._add_to_buffer(
-            area_uuid,
+            asset_uuid,
             Commands.BID,
             {"energy": energy, "price": price, "replace_existing": replace_existing,
              "attributes": attributes, "requirements": requirements, "time_slot": time_slot})
 
     def bid_energy_rate(
-            self, area_uuid: str, energy: float, rate: float, replace_existing: bool = True,
+            self, asset_uuid: str, energy: float, rate: float, replace_existing: bool = True,
             attributes: Dict = None, requirements: List[Dict] = None, time_slot: str = None):
-
+        """Add a command to issue a bid with the given energy rate and additional parameters."""
         return self._add_to_buffer(
-            area_uuid,
+            asset_uuid,
             Commands.BID,
             {"energy": energy, "price": rate * energy, "replace_existing": replace_existing,
              "attributes": attributes, "requirements": requirements, "time_slot": time_slot})
 
     def update_bid(self, *args, **kwargs):
+        """Add a command to update a bid."""
         logging.warning("update_bid is deprecated,"
                         " use bid_energy with replace_existing=True instead.")
 
-    def delete_offer(self, area_uuid, offer_id, time_slot: str = None):
-        return self._add_to_buffer(area_uuid, Commands.DELETE_OFFER,
+    def delete_offer(self, asset_uuid, offer_id, time_slot: str = None):
+        """
+        Add a command to delete a specific offer from a specific asset in the given time slot.
+        """
+        return self._add_to_buffer(asset_uuid, Commands.DELETE_OFFER,
                                    {"offer_id": offer_id, "time_slot": time_slot})
 
-    def delete_bid(self, area_uuid, bid_id, time_slot: str = None):
-        return self._add_to_buffer(area_uuid, Commands.DELETE_BID,
+    def delete_bid(self, asset_uuid, bid_id, time_slot: str = None):
+        """Add a command to delete a specific bid from a specific asset, in the given time slot."""
+        return self._add_to_buffer(asset_uuid, Commands.DELETE_BID,
                                    {"bid_id": bid_id, "time_slot": time_slot})
 
-    def list_offers(self, area_uuid, time_slot: str = None):
-        return self._add_to_buffer(area_uuid, Commands.LIST_OFFERS, {"time_slot": time_slot})
+    def list_offers(self, asset_uuid, time_slot: str = None):
+        """Add a command to list offers made by a specific asset in the given time slot."""
+        return self._add_to_buffer(asset_uuid, Commands.LIST_OFFERS, {"time_slot": time_slot})
 
-    def list_bids(self, area_uuid, time_slot: str = None):
-        return self._add_to_buffer(area_uuid, Commands.LIST_BIDS, {"time_slot": time_slot})
+    def list_bids(self, asset_uuid, time_slot: str = None):
+        """Add a command to list bids made by a specific asset in the given time slot."""
+        return self._add_to_buffer(asset_uuid, Commands.LIST_BIDS, {"time_slot": time_slot})
 
     def device_info(self, area_uuid):
         """Retrieve information about the asset identified by the given UUID.
@@ -90,23 +103,28 @@ class ClientCommandBuffer:
         return self._add_to_buffer(asset_uuid, Commands.ASSET_INFO, {})
 
     def last_market_dso_stats(self, area_uuid):
+        """Add a command to retrieve the statistics of a Distribution System Operator."""
         return self._add_to_buffer(area_uuid, Commands.DSO_MARKET_STATS, {"data": {}})
 
-    def set_energy_forecast(self, area_uuid, energy_forecast_kWh: Dict):
-        return self._add_to_buffer(area_uuid, Commands.FORECAST,
+    def set_energy_forecast(self, asset_uuid, energy_forecast_kWh: Dict):
+        """Add a command to set the energy forecast of the given asset."""
+        return self._add_to_buffer(asset_uuid, Commands.FORECAST,
                                    {"energy_forecast": energy_forecast_kWh})
 
-    def set_energy_measurement(self, area_uuid, energy_measurement_kWh: Dict):
-        return self._add_to_buffer(area_uuid, Commands.MEASUREMENT,
+    def set_energy_measurement(self, asset_uuid, energy_measurement_kWh: Dict):
+        """Add a command to set the actual energy measurement of the given asset."""
+        return self._add_to_buffer(asset_uuid, Commands.MEASUREMENT,
                                    {"energy_measurement": energy_measurement_kWh})
 
     def change_grid_fees_percent(self, area_uuid, fee_percent):
+        """Add a command to change the grid fees of the given market using a percentual value."""
         return self._add_to_buffer(
             area_uuid,
             Commands.GRID_FEES,
             {"data": {"fee_percent": fee_percent}})
 
     def grid_fees(self, area_uuid, fee_cents_kwh):
+        """Add a command to change the grid fees of the given market using a constant value."""
         return self._add_to_buffer(
             area_uuid,
             Commands.GRID_FEES,
@@ -116,15 +134,17 @@ class ClientCommandBuffer:
         if area_uuid and action:
             self._commands_buffer.append(
                 {area_uuid: {"type": command_enum_to_command_name(action)
-                             if type(action) == Commands else action, **args, **args}})
+                             if isinstance(action, Commands) else action, **args, **args}})
             logging.debug("Added Command to buffer, updated buffer: ")
-            self.log_all_commands()
+            self._log_all_commands()
         return self
 
     def clear(self):
+        """Remove all commands that were previously added to the buffer."""
         self._commands_buffer.clear()
 
-    def log_all_commands(self):
+    def _log_all_commands(self):
+        """Log all commands that were previously added to the buffer."""
         table_headers = ["Area UUID", "Command Type", "Arguments"]
         table_data = []
         for command_dict in self._commands_buffer:
@@ -132,9 +152,11 @@ class ClientCommandBuffer:
             command_type = command_dict[area_uuid]["type"]
             command_args = str(command_dict[area_uuid])
             table_data.append([area_uuid, command_type, command_args])
-        logging.debug(f"\n\n{tabulate(table_data, headers=table_headers, tablefmt='fancy_grid')}\n\n")
+        logging.debug(
+            "\n\n%s\n\n", tabulate(table_data, headers=table_headers, tablefmt="fancy_grid"))
 
     def execute_batch(self):
+        """Send to the exchange all the commands that were previously added to the buffer."""
         batch_command_dict = {}
         for command_dict in self._commands_buffer:
             area_uuid = list(command_dict.keys())[0]

--- a/gsy_e_sdk/setups/asset_api_template.py
+++ b/gsy_e_sdk/setups/asset_api_template.py
@@ -156,13 +156,13 @@ class Oracle(aggregator_client_type):
             if "energy_requirement_kWh" in area_dict["asset_info"] and area_dict["asset_info"]["energy_requirement_kWh"] > 0.0:
                 rate = self.asset_strategy[area_uuid]["buy_rates"][0]
                 energy = area_dict["asset_info"]["energy_requirement_kWh"]
-                self.add_to_batch_commands.bid_energy_rate(area_uuid=area_uuid, rate=rate, energy=energy)
+                self.add_to_batch_commands.bid_energy_rate(asset_uuid=area_uuid, rate=rate, energy=energy)
 
             # Generation strategy
             if "available_energy_kWh" in area_dict["asset_info"] and area_dict["asset_info"]["available_energy_kWh"] > 0.0:
                 rate = self.asset_strategy[area_uuid]["sell_rates"][0]
                 energy = area_dict["asset_info"]["available_energy_kWh"]
-                self.add_to_batch_commands.offer_energy_rate(area_uuid=area_uuid, rate=rate, energy=energy)
+                self.add_to_batch_commands.offer_energy_rate(asset_uuid=area_uuid, rate=rate, energy=energy)
 
             # Battery strategy
             if "energy_to_buy" in area_dict["asset_info"]:
@@ -171,11 +171,11 @@ class Oracle(aggregator_client_type):
                 # Battery buy strategy
                 if buy_energy > 0.0:
                     buy_rate = self.asset_strategy[area_uuid]["buy_rates"][0]
-                    self.add_to_batch_commands.bid_energy_rate(area_uuid=area_uuid, rate=buy_rate, energy=buy_energy)
+                    self.add_to_batch_commands.bid_energy_rate(asset_uuid=area_uuid, rate=buy_rate, energy=buy_energy)
                 # Battery sell strategy
                 if sell_energy > 0.0:
                     sell_rate = self.asset_strategy[area_uuid]["sell_rates"][0]
-                    self.add_to_batch_commands.offer_energy_rate(area_uuid=area_uuid, rate=sell_rate, energy=sell_energy)
+                    self.add_to_batch_commands.offer_energy_rate(asset_uuid=area_uuid, rate=sell_rate, energy=sell_energy)
 
         response_slot = self.execute_batch_commands()
 
@@ -207,14 +207,14 @@ class Oracle(aggregator_client_type):
                 "energy_requirement_kWh"] > 0.0:
                 rate = self.asset_strategy[area_uuid]["buy_rates"][i]
                 energy = area_dict["asset_info"]["energy_requirement_kWh"]
-                self.add_to_batch_commands.bid_energy_rate(area_uuid=area_uuid, rate=rate, energy=energy)
+                self.add_to_batch_commands.bid_energy_rate(asset_uuid=area_uuid, rate=rate, energy=energy)
 
             # Generation strategy
             if "available_energy_kWh" in area_dict["asset_info"] and area_dict["asset_info"][
                 "available_energy_kWh"] > 0.0:
                 rate = self.asset_strategy[area_uuid]["sell_rates"][i]
                 energy = area_dict["asset_info"]["available_energy_kWh"]
-                self.add_to_batch_commands.offer_energy(area_uuid=area_uuid, price=rate*energy,
+                self.add_to_batch_commands.offer_energy(asset_uuid=area_uuid, price=rate*energy,
                                                         energy=energy, replace_existing=True)
 
             # Battery strategy
@@ -225,12 +225,12 @@ class Oracle(aggregator_client_type):
                 # Battery buy strategy
                 if buy_energy > 0.0:
                     buy_rate = self.asset_strategy[area_uuid]["buy_rates"][i]
-                    self.add_to_batch_commands.bid_energy_rate(area_uuid=area_uuid, rate=buy_rate, energy=buy_energy)
+                    self.add_to_batch_commands.bid_energy_rate(asset_uuid=area_uuid, rate=buy_rate, energy=buy_energy)
 
                 # Battery sell strategy
                 if sell_energy > 0.0:
                     sell_rate = self.asset_strategy[area_uuid]["sell_rates"][i]
-                    self.add_to_batch_commands.offer_energy(area_uuid=area_uuid,
+                    self.add_to_batch_commands.offer_energy(asset_uuid=area_uuid,
                                                             price=sell_rate*sell_energy,
                                                             energy=sell_energy,
                                                             replace_existing=True)

--- a/gsy_e_sdk/setups/test_create_aggregator.py
+++ b/gsy_e_sdk/setups/test_create_aggregator.py
@@ -42,13 +42,13 @@ class TestAggregator(Aggregator):
                 if key_in_dict_and_not_none_and_greater_than_zero(area_dict["asset_info"],
                                                                   "available_energy_kWh"):
                     energy = area_dict["asset_info"]["available_energy_kWh"] / 2
-                    self.add_to_batch_commands.offer_energy(area_uuid=area_uuid, price=1,
+                    self.add_to_batch_commands.offer_energy(asset_uuid=area_uuid, price=1,
                                                             energy=energy)
 
                 if key_in_dict_and_not_none_and_greater_than_zero(area_dict["asset_info"],
                                                                   "energy_requirement_kWh"):
                     energy = area_dict["asset_info"]["energy_requirement_kWh"] / 2
-                    self.add_to_batch_commands.bid_energy(area_uuid=area_uuid, price=30,
+                    self.add_to_batch_commands.bid_energy(asset_uuid=area_uuid, price=30,
                                                           energy=energy)
 
         response = self.execute_batch_commands()

--- a/gsy_e_sdk/setups/test_ess_bid_redis_aggregator.py
+++ b/gsy_e_sdk/setups/test_ess_bid_redis_aggregator.py
@@ -19,9 +19,9 @@ class AutoAggregator(RedisAggregator):
             if "energy_to_buy" in device_event["device_info"] and \
                     device_event["device_info"]["energy_to_buy"] > 0.0:
                 buy_energy = device_event["device_info"]["energy_to_buy"] / 2
-                self.add_to_batch_commands.bid_energy(area_uuid=device_event["area_uuid"],
+                self.add_to_batch_commands.bid_energy(asset_uuid=device_event["area_uuid"],
                                                       price=31 * buy_energy, energy=buy_energy).\
-                    list_bids(area_uuid=device_event["area_uuid"])
+                    list_bids(asset_uuid=device_event["area_uuid"])
 
         response = self.execute_batch_commands(batch_commands)
         logging.info(f"Batch command placed on the new market: {response}")

--- a/gsy_e_sdk/setups/test_ess_bid_redis_aggregator.py
+++ b/gsy_e_sdk/setups/test_ess_bid_redis_aggregator.py
@@ -21,7 +21,7 @@ class AutoAggregator(RedisAggregator):
                 buy_energy = device_event["device_info"]["energy_to_buy"] / 2
                 self.add_to_batch_commands.bid_energy(asset_uuid=device_event["area_uuid"],
                                                       price=31 * buy_energy, energy=buy_energy).\
-                    list_bids(asset_uuid=device_event["area_uuid"])
+                    list_bids(area_uuid=device_event["area_uuid"])
 
         response = self.execute_batch_commands(batch_commands)
         logging.info(f"Batch command placed on the new market: {response}")

--- a/gsy_e_sdk/setups/test_redis_aggregator.py
+++ b/gsy_e_sdk/setups/test_redis_aggregator.py
@@ -26,12 +26,12 @@ class AutoAggregator(RedisAggregator):
                 if key_in_dict_and_not_none_and_greater_than_zero(area_dict["asset_info"],
                                                                   "available_energy_kWh"):
                     energy = area_dict["asset_info"]["available_energy_kWh"] / 2
-                    self.add_to_batch_commands.offer_energy(area_uuid=area_uuid, price=1,
+                    self.add_to_batch_commands.offer_energy(asset_uuid=area_uuid, price=1,
                                                             energy=energy)
                 if key_in_dict_and_not_none_and_greater_than_zero(area_dict["asset_info"],
                                                                   "energy_requirement_kWh"):
                     energy = area_dict["asset_info"]["energy_requirement_kWh"] / 2
-                    self.add_to_batch_commands.bid_energy(area_uuid=area_uuid, price=30,
+                    self.add_to_batch_commands.bid_energy(asset_uuid=area_uuid, price=30,
                                                           energy=energy)
 
             response = self.execute_batch_commands()

--- a/integration_tests/test_aggregator_batch_commands.py
+++ b/integration_tests/test_aggregator_batch_commands.py
@@ -70,7 +70,7 @@ class BatchAggregator(TestAggregatorBase):
                         energy=asset_info["available_energy_kWh"] / 4,
                         replace_existing=False,
                         attributes={"energy_type": "PV"}
-                    ).list_offers(asset_uuid=area_uuid)
+                    ).list_offers(area_uuid=area_uuid)
 
                 if self._can_place_bid(asset_info):
                     self.add_to_batch_commands.bid_energy(
@@ -98,7 +98,7 @@ class BatchAggregator(TestAggregatorBase):
                         replace_existing=False,
                         requirements=[{"price": 30 / (asset_info["energy_requirement_kWh"] / 4)}]
                     ).list_bids(
-                        asset_uuid=area_uuid
+                        area_uuid=area_uuid
                     )
                 if self._can_place_forecast_measurements(area_dict):
                     next_market_slot_str = (from_format(market_info["market_slot"], DATE_TIME_FORMAT).

--- a/integration_tests/test_aggregator_batch_commands.py
+++ b/integration_tests/test_aggregator_batch_commands.py
@@ -47,67 +47,67 @@ class BatchAggregator(TestAggregatorBase):
                 asset_info = area_dict["asset_info"]
                 if self._can_place_offer(asset_info):
                     self.add_to_batch_commands.offer_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=1.1,
                         energy=asset_info["available_energy_kWh"] / 4,
                         replace_existing=False,
                         attributes={"energy_type": "PV"}
                     ).offer_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=2.2,
                         energy=asset_info["available_energy_kWh"] / 4,
                         replace_existing=False,
                         attributes={"energy_type": "PV"}
                     ).offer_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=3.3,
                         energy=asset_info["available_energy_kWh"] / 4,
                         replace_existing=True,
                         attributes={"energy_type": "PV"}
                     ).offer_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=4.4,
                         energy=asset_info["available_energy_kWh"] / 4,
                         replace_existing=False,
                         attributes={"energy_type": "PV"}
-                    ).list_offers(area_uuid=area_uuid)
+                    ).list_offers(asset_uuid=area_uuid)
 
                 if self._can_place_bid(asset_info):
                     self.add_to_batch_commands.bid_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=27,
                         energy=asset_info["energy_requirement_kWh"] / 4,
                         replace_existing=False,
                         requirements=[{"price": 27 / (asset_info["energy_requirement_kWh"] / 4)}]
                     ).bid_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=28,
                         energy=asset_info["energy_requirement_kWh"] / 4,
                         replace_existing=False,
                         requirements=[{"price": 28 / (asset_info["energy_requirement_kWh"] / 4)}]
                     ).bid_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=29,
                         energy=asset_info["energy_requirement_kWh"] / 4,
                         replace_existing=True,
                         requirements=[{"price": 29 / (asset_info["energy_requirement_kWh"] / 4)}]
                     ).bid_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=30,
                         energy=asset_info["energy_requirement_kWh"] / 4,
                         replace_existing=False,
                         requirements=[{"price": 30 / (asset_info["energy_requirement_kWh"] / 4)}]
                     ).list_bids(
-                        area_uuid=area_uuid
+                        asset_uuid=area_uuid
                     )
                 if self._can_place_forecast_measurements(area_dict):
                     next_market_slot_str = (from_format(market_info["market_slot"], DATE_TIME_FORMAT).
                                             add(minutes=15).format(DATE_TIME_FORMAT))
                     self.add_to_batch_commands.set_energy_forecast(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         energy_forecast_kWh={next_market_slot_str: 1234.0}
                     ).set_energy_measurement(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         energy_measurement_kWh={next_market_slot_str: 2345.0}
                     )
 

--- a/integration_tests/test_aggregator_ess.py
+++ b/integration_tests/test_aggregator_ess.py
@@ -27,7 +27,7 @@ class EssAggregator(TestAggregatorBase):
                     bid_energy = asset_info["energy_to_buy"]
                     bid_price = 31 * bid_energy
                     self.add_to_batch_commands.bid_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=bid_price,
                         energy=bid_energy,
                         replace_existing=False
@@ -37,7 +37,7 @@ class EssAggregator(TestAggregatorBase):
                     offer_energy = asset_info["energy_to_sell"]
                     offer_price = 10 * offer_energy
                     self.add_to_batch_commands.offer_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=offer_price,
                         energy=offer_energy,
                         replace_existing=False

--- a/integration_tests/test_aggregator_load.py
+++ b/integration_tests/test_aggregator_load.py
@@ -29,7 +29,7 @@ class LoadAggregator(TestAggregatorBase):
                     bid_energy = asset_info["energy_requirement_kWh"]
                     bid_price = 0.0001 * bid_energy
                     self.add_to_batch_commands.bid_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=bid_price,
                         energy=bid_energy,
                         replace_existing=False

--- a/integration_tests/test_aggregator_pv.py
+++ b/integration_tests/test_aggregator_pv.py
@@ -29,7 +29,7 @@ class PVAggregator(TestAggregatorBase):
                     offer_energy = asset_info["available_energy_kWh"]
                     offer_price = 50 * offer_energy
                     self.add_to_batch_commands.offer_energy(
-                        area_uuid=area_uuid,
+                        asset_uuid=area_uuid,
                         price=offer_price,
                         energy=offer_energy,
                         replace_existing=False


### PR DESCRIPTION
I've left some methods out of the renaming because I suppose they can be called for both markets and assets (or only for markets). Let me know if they also need to be amended.