### PR TITLE
Improve test error logging

### DIFF
--- a/integration_tests/steps/device.py
+++ b/integration_tests/steps/device.py
@@ -90,7 +90,7 @@ def step_impl(context):
     # Should stop if an error occurs or if the simulation has finished
     counter = 0  # Wait for five minutes at most
     while (
-            context.aggregator.errors == 0
+            len(context.aggregator.errors) == 0
             and context.aggregator.status != "finished"
             and counter < 60):
         sleep(3)
@@ -99,7 +99,8 @@ def step_impl(context):
 
 @then("the external client does not report errors")
 def step_impl(context):
-    assert context.aggregator.errors == 0
+    assert len(context.aggregator.errors) == 0, \
+        f"The following errors were reported: {context.aggregator.errors}"
 
 
 @then("the energy bills of the load report the required energy was bought by the load")

--- a/integration_tests/steps/device.py
+++ b/integration_tests/steps/device.py
@@ -1,8 +1,11 @@
+# pylint: disable=missing-function-docstring
+# pylint: disable=function-redefined
+# pylint: disable=unused-argument
 from math import isclose
 from os import system
 from time import sleep
 
-from behave import given, when, then
+from behave import given, when, then  # pylint: disable=no-name-in-module
 
 from integration_tests.test_aggregator_batch_commands import BatchAggregator
 from integration_tests.test_aggregator_ess import EssAggregator
@@ -12,7 +15,7 @@ from integration_tests.test_aggregator_pv import PVAggregator
 
 @given("redis container is started")
 def step_impl(context):
-    system(f"docker run -d -p 6379:6379 --name redis.container -h redis.container "
+    system("docker run -d -p 6379:6379 --name redis.container -h redis.container "
            "--net integtestnet redis:6.2.5")
 
 
@@ -25,7 +28,7 @@ def step_impl(context, setup_file: str, gsy_e_options: str):
         gsy_e_options (str): options to be passed to the d3a run command. E.g.: "-t 1s -d 12h"
     """
     sleep(3)
-    system(f"docker run -d --name gsy-e-tests --env REDIS_URL=redis://redis.container:6379/ "
+    system("docker run -d --name gsy-e-tests --env REDIS_URL=redis://redis.container:6379/ "
            f"--net integtestnet gsy-e-tests -l INFO run --setup {setup_file} "
            f"--no-export --seed 0 --enable-external-connection {gsy_e_options} ")
 
@@ -63,11 +66,12 @@ def step_impl(context):
 @then("the on_event_or_response is called for different events")
 def step_impl(context):
     # Check if the market event triggered both the on_market_cycle and on_event_or_response
-    assert context.aggregator.events == {"event", "command",
-                                     "tick", "register",
-                                     "offer_delete", "trade",
-                                     "offer", "unregister",
-                                     "list_offers", "market", "finish"}
+    assert context.aggregator.events == {
+        "event", "command",
+        "tick", "register",
+        "offer_delete", "trade",
+        "offer", "unregister",
+        "list_offers", "market", "finish"}
     assert context.aggregator.is_on_market_cycle_called
 
 
@@ -85,7 +89,10 @@ def step_impl(context):
     # placing bids and offers on every market cycle.
     # Should stop if an error occurs or if the simulation has finished
     counter = 0  # Wait for five minutes at most
-    while context.aggregator.errors == 0 and context.aggregator.status != "finished" and counter < 60:
+    while (
+            context.aggregator.errors == 0
+            and context.aggregator.status != "finished"
+            and counter < 60):
         sleep(3)
         counter += 3
 
@@ -98,4 +105,3 @@ def step_impl(context):
 @then("the energy bills of the load report the required energy was bought by the load")
 def step_impl(context):
     assert isclose(context.aggregator.device_bills["bought"], 22 * 0.2)
-

--- a/integration_tests/test_aggregator_base.py
+++ b/integration_tests/test_aggregator_base.py
@@ -4,6 +4,8 @@ from gsy_e_sdk.redis_aggregator import RedisAggregator
 
 
 class TestAggregatorBase(RedisAggregator):
+    """Aggregator class to be used for running tests."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.errors = 0
@@ -20,6 +22,7 @@ class TestAggregatorBase(RedisAggregator):
         pass
 
     def send_batch_commands(self):
+        """Send accumulated batch commands to the exchange."""
         if self.commands_buffer_length:
             transaction = self.execute_batch_commands()
             if transaction is None:
@@ -29,13 +32,15 @@ class TestAggregatorBase(RedisAggregator):
                     for command_dict in response:
                         if command_dict["status"] == "error":
                             self.errors += 1
-            logging.info(f"Batch command placed on the new market")
+            logging.info("Batch command placed on the new market")
             return transaction
+
+        return None
 
     @staticmethod
     def _filter_commands_from_responses(responses, command_name):
         filtered_commands = []
-        for area_uuid, response in responses.items():
+        for response in responses.values():
             for command_dict in response:
                 if command_dict["command"] == command_name:
                     filtered_commands.append(command_dict)

--- a/integration_tests/test_aggregator_base.py
+++ b/integration_tests/test_aggregator_base.py
@@ -8,7 +8,7 @@ class TestAggregatorBase(RedisAggregator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.errors = 0
+        self.errors = []
         self.status = "running"
         self._setup()
         self.is_active = True
@@ -22,16 +22,18 @@ class TestAggregatorBase(RedisAggregator):
         pass
 
     def send_batch_commands(self):
-        """Send accumulated batch commands to the exchange."""
+        """Send the accumulated batch commands to the exchange."""
         if self.commands_buffer_length:
             transaction = self.execute_batch_commands()
             if transaction is None:
-                self.errors += 1
+                self.errors.append("Transaction was None after executing batch commands.")
             else:
                 for response in transaction["responses"].values():
                     for command_dict in response:
                         if command_dict["status"] == "error":
-                            self.errors += 1
+                            self.errors.append(
+                                "Error status received from response to batch commands.",
+                                f"Commands: {command_dict}")
             logging.info("Batch command placed on the new market")
             return transaction
 
@@ -61,8 +63,9 @@ class TestAggregatorBase(RedisAggregator):
     def on_finish(self, finish_info):
         # Make sure that all test cases have been run
         if self._has_tested_bids is False or self._has_tested_offers is False:
-            logging.error(
+            error_message = (
                 "Not all test cases have been covered. This will be reported as failure.")
-            self.errors += 1
+            logging.error(error_message)
+            self.errors.append(error_message)
 
         self.status = "finished"

--- a/integration_tests/test_aggregator_batch_commands.py
+++ b/integration_tests/test_aggregator_batch_commands.py
@@ -126,12 +126,14 @@ class BatchAggregator(TestAggregatorBase):
             if self.commands_buffer_length:
                 transaction = self.execute_batch_commands()
                 if transaction is None:
-                    self.errors += 1
+                    self.errors.append("Transaction was None after executing batch commands.")
                 else:
                     for response in transaction["responses"].values():
                         for command_dict in response:
                             if command_dict["status"] == "error":
-                                self.errors += 1
+                                self.errors.append(
+                                    "Error status received from response to batch commands.",
+                                    f"Commands: {command_dict}")
                 logging.info("Batch command placed on the new market")
 
                 # Make assertions about the bids, if they happened during this slot
@@ -229,8 +231,9 @@ class BatchAggregator(TestAggregatorBase):
                     self._has_tested_offers = True
 
         except Exception as ex:
-            logging.error(f"Raised exception: {ex}. Traceback: {traceback.format_exc()}")
-            self.errors += 1
+            error_message = f"Raised exception: {ex}. Traceback: {traceback.format_exc()}"
+            logging.error(error_message)
+            self.errors.append(error_message)
 
     def on_event_or_response(self, message):
         if "event" in message:

--- a/integration_tests/test_aggregator_ess.py
+++ b/integration_tests/test_aggregator_ess.py
@@ -16,7 +16,7 @@ class EssAggregator(TestAggregatorBase):
         storage.select_aggregator(self.aggregator_uuid)
 
     def on_market_cycle(self, market_info):
-        logging.info(f"market_info: {market_info}")
+        logging.info("market_info: %s", market_info)
         try:
 
             for area_uuid, area_dict in self.latest_grid_tree_flat.items():
@@ -57,7 +57,8 @@ class EssAggregator(TestAggregatorBase):
                         bid = json.loads(bid_response["bid"])
                         assert bid_response["status"] == "ready"
                         assert bid["buyer_origin"] == bid["buyer"] == "storage"
-                        assert bid["buyer_origin_id"] == bid["buyer_id"] == bid_response["area_uuid"]
+                        assert bid["buyer_origin_id"] == bid["buyer_id"] == bid_response[
+                            "area_uuid"]
                         assert bid["price"] == bid_price
                         assert bid["energy"] == bid_energy
                         self._has_tested_bids = True
@@ -76,11 +77,9 @@ class EssAggregator(TestAggregatorBase):
                         assert offer["energy"] == offer_energy
 
                         self._has_tested_offers = True
-
         except Exception as ex:
             logging.error(f"Raised exception: {ex}. Traceback: {traceback.format_exc()}")
             self.errors += 1
-
 
     @staticmethod
     def _can_place_bid(asset_info):

--- a/integration_tests/test_aggregator_ess.py
+++ b/integration_tests/test_aggregator_ess.py
@@ -18,7 +18,6 @@ class EssAggregator(TestAggregatorBase):
     def on_market_cycle(self, market_info):
         logging.info("market_info: %s", market_info)
         try:
-
             for area_uuid, area_dict in self.latest_grid_tree_flat.items():
                 if not area_dict.get("asset_info"):
                     continue
@@ -78,8 +77,9 @@ class EssAggregator(TestAggregatorBase):
 
                         self._has_tested_offers = True
         except Exception as ex:
-            logging.error(f"Raised exception: {ex}. Traceback: {traceback.format_exc()}")
-            self.errors += 1
+            error_message = f"Raised exception: {ex}. Traceback: {traceback.format_exc()}"
+            logging.error(error_message)
+            self.errors.append(error_message)
 
     @staticmethod
     def _can_place_bid(asset_info):

--- a/integration_tests/test_aggregator_load.py
+++ b/integration_tests/test_aggregator_load.py
@@ -68,4 +68,4 @@ class LoadAggregator(TestAggregatorBase):
         except Exception as ex:
             error_message = f"Raised exception: {ex}. Traceback: {traceback.format_exc()}"
             logging.error(error_message)
-            self.errors += 1
+            self.errors.append(error_message)

--- a/integration_tests/test_aggregator_load.py
+++ b/integration_tests/test_aggregator_load.py
@@ -7,6 +7,8 @@ from integration_tests.test_aggregator_base import TestAggregatorBase
 
 
 class LoadAggregator(TestAggregatorBase):
+    """Aggregator class to test the behaviour of load assets."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Load only places bids and does not have to be tested for placing offers
@@ -17,7 +19,7 @@ class LoadAggregator(TestAggregatorBase):
         load.select_aggregator(self.aggregator_uuid)
 
     def on_market_cycle(self, market_info):
-        logging.info(f"market_info: {market_info}")
+        logging.info("market_info: %s", market_info)
         try:
 
             for area_uuid, area_dict in self.latest_grid_tree_flat.items():
@@ -32,8 +34,7 @@ class LoadAggregator(TestAggregatorBase):
                         area_uuid=area_uuid,
                         price=bid_price,
                         energy=bid_energy,
-                        replace_existing=False
-                    )
+                        replace_existing=False)
 
                 transactions = self.send_batch_commands()
                 if transactions:
@@ -64,9 +65,7 @@ class LoadAggregator(TestAggregatorBase):
                     assert bid["energy"] == bid_energy
 
                     self._has_tested_bids = True
-
         except Exception as ex:
-            logging.error(f"Raised exception: {ex}. Traceback: {traceback.format_exc()}")
+            error_message = f"Raised exception: {ex}. Traceback: {traceback.format_exc()}"
+            logging.error(error_message)
             self.errors += 1
-
-

--- a/integration_tests/test_aggregator_market.py
+++ b/integration_tests/test_aggregator_market.py
@@ -16,10 +16,9 @@ class MarketAggregator(TestAggregatorBase):
         self.house_market.select_aggregator(self.aggregator_uuid)
 
     def on_market_cycle(self, market_info):
-        logging.info(f"market_info: {market_info}")
+        logging.info("market_info: %s", market_info)
         try:
-
-            for area_uuid, area_dict in self.latest_grid_tree_flat.items():
+            for area_uuid in self.latest_grid_tree_flat:
                 if area_uuid == self.house_market.area_uuid:
                     self.add_to_batch_commands.grid_fees(area_uuid=self.house_market.area_uuid,
                                                          fee_cents_kwh=self.grid_fee_cents_kwh)
@@ -37,9 +36,9 @@ class MarketAggregator(TestAggregatorBase):
                             transactions["responses"], "dso_market_stats")
                         assert len(stats_requests) == 1
                         assert set(stats_requests[0]["market_stats"]) == \
-                            {"min_trade_rate", "max_trade_rate", "avg_trade_rate", 
-                             "median_trade_rate", "total_traded_energy_kWh", "market_bill", 
-                             "market_fee_revenue", "area_throughput", "self_sufficiency", 
+                            {"min_trade_rate", "max_trade_rate", "avg_trade_rate",
+                             "median_trade_rate", "total_traded_energy_kWh", "market_bill",
+                             "market_fee_revenue", "area_throughput", "self_sufficiency",
                              "self_consumption"}
                         self._has_tested_market = True
 

--- a/integration_tests/test_aggregator_market.py
+++ b/integration_tests/test_aggregator_market.py
@@ -43,14 +43,16 @@ class MarketAggregator(TestAggregatorBase):
                         self._has_tested_market = True
 
         except Exception as ex:
-            logging.error(f"Raised exception: {ex}. Traceback: {traceback.format_exc()}")
-            self.errors += 1
+            error_message = f"Raised exception: {ex}. Traceback: {traceback.format_exc()}"
+            logging.error(error_message)
+            self.errors.append(error_message)
 
     def on_finish(self, finish_info):
         # Make sure that all test cases have been run
         if self._has_tested_market is False:
-            logging.error(
+            error_message = (
                 "Not all test cases have been covered. This will be reported as failure.")
-            self.errors += 1
+            logging.error(error_message)
+            self.errors.append(error_message)
 
         self.status = "finished"

--- a/integration_tests/test_aggregator_pv.py
+++ b/integration_tests/test_aggregator_pv.py
@@ -17,7 +17,7 @@ class PVAggregator(TestAggregatorBase):
         pv.select_aggregator(self.aggregator_uuid)
 
     def on_market_cycle(self, market_info):
-        logging.info(f"market_info: {market_info}")
+        logging.info("market_info: %s", market_info)
         try:
 
             for area_uuid, area_dict in self.latest_grid_tree_flat.items():
@@ -68,5 +68,3 @@ class PVAggregator(TestAggregatorBase):
         except Exception as ex:
             logging.error(f"Raised exception: {ex}. Traceback: {traceback.format_exc()}")
             self.errors += 1
-
-

--- a/integration_tests/test_aggregator_pv.py
+++ b/integration_tests/test_aggregator_pv.py
@@ -66,5 +66,6 @@ class PVAggregator(TestAggregatorBase):
                     self._has_tested_offers = True
 
         except Exception as ex:
-            logging.error(f"Raised exception: {ex}. Traceback: {traceback.format_exc()}")
-            self.errors += 1
+            error_message = f"Raised exception: {ex}. Traceback: {traceback.format_exc()}"
+            logging.error(error_message)
+            self.errors.append(error_message)


### PR DESCRIPTION
Errors occurring in integration tests are often just reported without enough detail about their content. This PR converts the bare count of errors with a list of error messages. This will provide some more information about each error.