### PR TITLE
Fix quote error in utils

### DIFF
--- a/gsy_e_sdk/setups/extract_area_uuid_from_area_name.py
+++ b/gsy_e_sdk/setups/extract_area_uuid_from_area_name.py
@@ -3,14 +3,14 @@ import json
 import sys
 from gsy_e_sdk.utils import get_area_uuid_and_name_mapping_from_simulation_id
 
-# set login information for d3a web
+# set login information for gsy-web
 os.environ["API_CLIENT_USERNAME"] = str(sys.argv[1])
 os.environ["API_CLIENT_PASSWORD"] = str(sys.argv[2])
 
 # set simulation parameters
-simulation_id = str(sys.argv[3])
+SIMULATION_ID = str(sys.argv[3])
 
-mapping = get_area_uuid_and_name_mapping_from_simulation_id(simulation_id)
+mapping = get_area_uuid_and_name_mapping_from_simulation_id(SIMULATION_ID)
 
-with open(os.path.join(os.getcwd(), 'area_name_uuid_map.json'), "w") as outfile:
+with open(os.path.join(os.getcwd(), "area_name_uuid_map.json"), "w", encoding="utf-8") as outfile:
     json.dump(mapping, outfile, indent=2)

--- a/gsy_e_sdk/utils.py
+++ b/gsy_e_sdk/utils.py
@@ -110,8 +110,8 @@ def get_area_uuid_from_area_name_and_collaboration_id(
     Fire a request to get the scenario representation of the collaboration and
     search for the uuid of the area that name matches area_name.
     """
-    query = ("query { readConfiguration(uuid: '{" + collab_id +
-             "}') { scenarioData { latest { serialized } } } }")
+    query = '''query { readConfiguration(uuid: "''' + collab_id + '''")
+                { scenarioData { latest { serialized } } } }'''
     data = execute_graphql_request(domain_name=domain_name, query=query)
     area_uuid = get_area_uuid_from_area_name(
         json.loads(data["data"]["readConfiguration"]["scenarioData"]["latest"]["serialized"]),
@@ -128,8 +128,8 @@ def get_area_uuid_and_name_mapping_from_simulation_id(collab_id) -> dict:
     Fire a request to get the scenario representation of the collaboration and
     map for the uuid of the areas to their names.
     """
-    query = ("query { readConfiguration(uuid: '{" + collab_id +
-             "}') { scenarioData { latest { serialized } } } }")
+    query = '''query { readConfiguration(uuid: "''' + collab_id + '''")
+                { scenarioData { latest { serialized } } } }'''
 
     data = execute_graphql_request(domain_name=domain_name_from_env(), query=query)
     if data.get("errors"):


### PR DESCRIPTION
Fix for 
```
11:27:30.529 ERROR    ( 236) sgqlc.endpoint.http           : GraphQL query failed with 1 errors
11:27:30.529 INFO     ( 243) sgqlc.endpoint.http           : Error #0:
11:27:30.529 INFO     ( 245) sgqlc.endpoint.http           :    | Syntax Error GraphQL (1:33) Unexpected character "'".
11:27:30.529 INFO     ( 245) sgqlc.endpoint.http           :    | 
11:27:30.529 INFO     ( 245) sgqlc.endpoint.http           :    | 1: query { readConfiguration(uuid: '{0ea147ea-0d04-4069-a64b-39c8c27c05c5}') { scenarioData { latest { serialized } } } }
11:27:30.529 INFO     ( 245) sgqlc.endpoint.http           :    |                                    ^
11:27:30.529 INFO     ( 245) sgqlc.endpoint.http           :    | 
11:27:30.529 INFO     ( 249) sgqlc.endpoint.http           :    -
11:27:30.530 INFO     ( 250) sgqlc.endpoint.http           :    | Locations:
11:27:30.530 INFO     ( 252) sgqlc.endpoint.http           :    | 0 | query { readConfiguration(uuid: '{0ea147ea-0d04-4069-a64b-39c8c27c05c5}') { scenarioData { latest { serialized } } } }
11:27:30.530 INFO     ( 252) sgqlc.endpoint.http           :    |     --------------------------------^
Traceback (most recent call last):
  File "/usr/local/bin/gsy-e-sdk", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/gsy_e_sdk/cli.py", line 108, in run
    load_client_script(base_setup_path, setup_module_name)
  File "/usr/local/lib/python3.8/site-packages/gsy_e_sdk/cli.py", line 127, in load_client_script
    importlib.import_module(setup_module_name)
  File "/usr/local/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/gsy_e_sdk/setups/device_aggregator_test.py", line 75, in <module>
    load_uuid = get_area_uuid_from_area_name_and_collaboration_id(simulation_id, 'Load', domain_name)
  File "/usr/local/lib/python3.8/site-packages/gsy_e_sdk/utils.py", line 117, in get_area_uuid_from_area_name_and_collaboration_id
    json.loads(data["data"]["readConfiguration"]["scenarioData"]["latest"]["serialized"]),
KeyError: 'data'
```