### PR TITLE
TESTS-135: I want to enable calls to a particular branch of GBIT on a PR on any involved repository.

### DIFF
--- a/.github/pr_templates/pull_request_template.md
+++ b/.github/pr_templates/pull_request_template.md
@@ -1,0 +1,10 @@
+## Reason for the proposed changes
+
+Please describe what we want to achieve and why.
+
+## Proposed changes
+
+-
+
+<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
+**INTEGRATION_TESTS_BRANCH**=master

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -11,12 +11,28 @@
 
     steps:
       - uses: actions/checkout@v2
+      - uses: 8BitJonny/gh-get-current-pr@1.3.0
+        id: PR
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          filterOutClosed: true
+
+      - name: Parse integration tests branch
+        env:
+          prBody: ${{ steps.PR.outputs.pr_body }}
+        run: |
+          echo "::set-output name=INTEGRATION_TESTS_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*INTEGRATION_TESTS_BRANCH\*\*=\([^ ]*\).*/\1/p')"
+        id: parse_branch
+
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python }}
+
       - name: Install Tox
         run: pip install tox
+
       - name: Run Tox
         run: tox -e $TOXENV
         env:
@@ -24,3 +40,4 @@
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INTEGRATION_TESTS_REPO: https://gsydev:${{ secrets.GSYDEV_TOKEN }}@github.com/gridsingularity/gsy-backend-integration-tests.git
+          INTEGRATION_TESTS_BRANCH: ${{ steps.parse_branch.outputs.INTEGRATION_TESTS_BRANCH }}

--- a/tox.ini
+++ b/tox.ini
@@ -64,7 +64,7 @@ commands = python setup.py check --restructuredtext --strict
 
 [testenv:ci]
 basepython = python3.8
-passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH BRANCH INTEGRATION_TESTS_REPO
+passenv = LANG TERM LANGUAGE LC_ALL LD_LIBRARY_PATH BRANCH INTEGRATION_TESTS_REPO INTEGRATION_TESTS_BRANCH
 setenv =
     API_CLIENT_RUN_ON_REDIS = true
 deps =
@@ -78,7 +78,7 @@ commands_pre =
     python -c "import fcntl; fcntl.fcntl(1, fcntl.F_SETFL, 0)"
     pip install -e .
     pip install -r requirements/dev.txt
-    git clone {env:INTEGRATION_TESTS_REPO:git@github.com:gridsingularity/gsy-backend-integration-tests.git} {envtmpdir}/gsy-backend-integration-tests
+    git clone -b {env:INTEGRATION_TESTS_BRANCH:master} {env:INTEGRATION_TESTS_REPO:git@github.com:gridsingularity/gsy-backend-integration-tests.git} {envtmpdir}/gsy-backend-integration-tests
     ln -sf {envtmpdir}/gsy-backend-integration-tests/gsy_e_sdk_tests/integration_tests/ ./integration_tests
 commands =
     pytest unit_tests


### PR DESCRIPTION
Configure **gsy-e-sdk** workflow to call a particular `gsy-backend-integration-tests` branch on a PR.

GBIT repo’s tox file should be modified as well to support this possibility.

**INTEGRATION_TESTS_BRANCH**=feature/GSYE-194

A template to the PR message should be added to help open source users to be aware of this.