### PR TITLE
TESTS-141: As gsy-backend-integration-tests, I want to build a docker image with the latest changes of the working branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,3 +8,5 @@ Please describe what we want to achieve and why.
 
 <!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
 **INTEGRATION_TESTS_BRANCH**=master
+<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
+**TARGET_BRANCH**=master

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,4 +9,4 @@ Please describe what we want to achieve and why.
 <!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
 **INTEGRATION_TESTS_BRANCH**=master
 <!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
-**TARGET_BRANCH**=master
+**GSY_E_TARGET_BRANCH**=master

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -29,8 +29,8 @@
         env:
           prBody: ${{ steps.PR.outputs.pr_body }}
         run: |
-          echo "::set-output name=PARSED_TARGET_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*TARGET_BRANCH\*\*=\([^ ]*\).*/\1/p')"
-        id: parse_target_branch
+          echo "::set-output name=PARSED_GSY_E_TARGET_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*GSY_E_TARGET_BRANCH\*\*=\([^ ]*\).*/\1/p')"
+        id: parse_gsye_target_branch
 
       - name: Validate parsed integration tests branch
         env:
@@ -39,12 +39,12 @@
           echo "::set-output name=INTEGRATION_TESTS_BRANCH::${PARSED_INTEGRATION_TESTS_BRANCH:-'master'}"
         id: validated_integration_tests_branch
 
-      - name: Validate parsed target branch
+      - name: Validate parsed gsy-e target branch
         env:
-          PARSED_TARGET_BRANCH: ${{ steps.parse_target_branch.outputs.PARSED_TARGET_BRANCH }}
+          PARSED_GSY_E_TARGET_BRANCH: ${{ steps.parse_gsye_target_branch.outputs.PARSED_GSY_E_TARGET_BRANCH }}
         run: |
-          echo "::set-output name=TARGET_BRANCH::${PARSED_TARGET_BRANCH:-'master'}"
-        id: validated_target_branch
+          echo "::set-output name=GSY_E_TARGET_BRANCH::${PARSED_GSY_E_TARGET_BRANCH:-'master'}"
+        id: validated_gsye_target_branch
 
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -62,4 +62,4 @@
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INTEGRATION_TESTS_REPO: https://gsydev:${{ secrets.GSYDEV_TOKEN }}@github.com/gridsingularity/gsy-backend-integration-tests.git
           INTEGRATION_TESTS_BRANCH: ${{ steps.validated_integration_tests_branch.outputs.INTEGRATION_TESTS_BRANCH }}
-          TARGET_BRANCH: ${{ steps.validated_target_branch.outputs.TARGET_BRANCH }}
+          GSY_E_TARGET_BRANCH: ${{ steps.validated_gsye_target_branch.outputs.GSY_E_TARGET_BRANCH }}

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -23,14 +23,28 @@
           prBody: ${{ steps.PR.outputs.pr_body }}
         run: |
           echo "::set-output name=PARSED_INTEGRATION_TESTS_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*INTEGRATION_TESTS_BRANCH\*\*=\([^ ]*\).*/\1/p')"
-        id: parse_branch
+        id: parse_int_tests_branch
 
-      - name: Validate parsed branch
+      - name: Parse gsy-e image target branch
         env:
-          PARSED_INTEGRATION_TESTS_BRANCH: ${{ steps.parse_branch.outputs.PARSED_INTEGRATION_TESTS_BRANCH }}
+          prBody: ${{ steps.PR.outputs.pr_body }}
+        run: |
+          echo "::set-output name=PARSED_TARGET_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*TARGET_BRANCH\*\*=\([^ ]*\).*/\1/p')"
+        id: parse_target_branch
+
+      - name: Validate parsed integration tests branch
+        env:
+          PARSED_INTEGRATION_TESTS_BRANCH: ${{ steps.parse_int_tests_branch.outputs.PARSED_INTEGRATION_TESTS_BRANCH }}
         run: |
           echo "::set-output name=INTEGRATION_TESTS_BRANCH::${PARSED_INTEGRATION_TESTS_BRANCH:-'master'}"
-        id: validated_branch
+        id: validated_int_tests_branch
+
+      - name: Validate parsed target branch
+        env:
+          PARSED_TARGET_BRANCH: ${{ steps.parse_target_branch.outputs.PARSED_TARGET_BRANCH }}
+        run: |
+          echo "::set-output name=TARGET_BRANCH::${PARSED_TARGET_BRANCH:-'master'}"
+        id: validated_target_branch
 
       - name: Setup Python
         uses: actions/setup-python@v1
@@ -47,4 +61,5 @@
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INTEGRATION_TESTS_REPO: https://gsydev:${{ secrets.GSYDEV_TOKEN }}@github.com/gridsingularity/gsy-backend-integration-tests.git
-          INTEGRATION_TESTS_BRANCH: ${{ steps.validated_branch.outputs.INTEGRATION_TESTS_BRANCH }}
+          INTEGRATION_TESTS_BRANCH: ${{ steps.validated_int_tests_branch.outputs.INTEGRATION_TESTS_BRANCH }}
+          TARGET_BRANCH: ${{ steps.validated_target_branch.outputs.TARGET_BRANCH }}

--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -23,7 +23,7 @@
           prBody: ${{ steps.PR.outputs.pr_body }}
         run: |
           echo "::set-output name=PARSED_INTEGRATION_TESTS_BRANCH::$(echo -e $prBody | sed -n 's/.*\*\*INTEGRATION_TESTS_BRANCH\*\*=\([^ ]*\).*/\1/p')"
-        id: parse_int_tests_branch
+        id: parse_integration_tests_branch
 
       - name: Parse gsy-e image target branch
         env:
@@ -34,10 +34,10 @@
 
       - name: Validate parsed integration tests branch
         env:
-          PARSED_INTEGRATION_TESTS_BRANCH: ${{ steps.parse_int_tests_branch.outputs.PARSED_INTEGRATION_TESTS_BRANCH }}
+          PARSED_INTEGRATION_TESTS_BRANCH: ${{ steps.parse_integration_tests_branch.outputs.PARSED_INTEGRATION_TESTS_BRANCH }}
         run: |
           echo "::set-output name=INTEGRATION_TESTS_BRANCH::${PARSED_INTEGRATION_TESTS_BRANCH:-'master'}"
-        id: validated_int_tests_branch
+        id: validated_integration_tests_branch
 
       - name: Validate parsed target branch
         env:
@@ -61,5 +61,5 @@
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
           INTEGRATION_TESTS_REPO: https://gsydev:${{ secrets.GSYDEV_TOKEN }}@github.com/gridsingularity/gsy-backend-integration-tests.git
-          INTEGRATION_TESTS_BRANCH: ${{ steps.validated_int_tests_branch.outputs.INTEGRATION_TESTS_BRANCH }}
+          INTEGRATION_TESTS_BRANCH: ${{ steps.validated_integration_tests_branch.outputs.INTEGRATION_TESTS_BRANCH }}
           TARGET_BRANCH: ${{ steps.validated_target_branch.outputs.TARGET_BRANCH }}

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ max-line-length = 99
 exclude = .tox,.cache,.pytest_cache
 
 [testenv:integrationtests]
-passenv = {[testenv]passenv} INTEGRATION_TESTS_REPO INTEGRATION_TESTS_BRANCH TARGET_BRANCH TARGET_REPO
+passenv = {[testenv]passenv} INTEGRATION_TESTS_REPO INTEGRATION_TESTS_BRANCH GSY_E_TARGET_BRANCH GSY_E_TARGET_REPO
 setenv =
     API_CLIENT_RUN_ON_REDIS = true
 allowlist_externals =


### PR DESCRIPTION
## Reason for proposed changes

- The migration of the integration tests to the current repository did not consider the need of creating a `gsy-e` image based on a particular branch when executing tests on gsy-myco-sdk and/or gsy-e-sdk, and therefore after the creation of a PR, the right image would not be built and tests would fail.

## Proposed changes

- Adapt PR template message to include the gsy-e TARGET_BRANCH that will be considered to build the docker image used by the tests.
- Adapt github actions to parse variable from PR body and pass it to the testenvs.


<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=TESTS-141
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=master