### PR TITLE
GSYE-274: Make --setup a required CLI option with no default value.

### DIFF
--- a/gsy_e_sdk/cli.py
+++ b/gsy_e_sdk/cli.py
@@ -66,7 +66,7 @@ _setup_modules = iterate_over_all_modules(modules_path)
 @main.command()
 @click.option("-b", "--base-setup-path", default=None, type=str,
               help="Accept absolute or relative path for client script")
-@click.option("--setup", "setup_module_name", default="auto_offer_bid_on_device",
+@click.option("--setup", "setup_module_name", required=True,
               help="Setup module of client script. Available modules: ["
                    f"{', '.join(_setup_modules)}]")
 @click.option("-u", "--username", default=None, type=str, help="D3A username")


### PR DESCRIPTION
## Reason for the proposed changes
As described in [GSYE-274](https://gridsingularity.atlassian.net/browse/GSYE-274), we need to force the user to enter a valid setup name.

## Proposed changes
- Make --setup option required.

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=master
<!--- If needed, choose which gsy-framework branch should be used to build docker image to execute integration tests.-->
**GSY_FRAMEWORK_BRANCH**=master
