### PR TITLE
fix gsy-e-sdk setup scripts

### DIFF
--- a/gsy_e_sdk/cli.py
+++ b/gsy_e_sdk/cli.py
@@ -121,7 +121,7 @@ def load_client_script(base_setup_path, setup_module_name):
     """Load client script."""
     try:
         if base_setup_path is None:
-            importlib.import_module(f"d3a_api_client.setups.{setup_module_name}")
+            importlib.import_module(f"gsy_e_sdk.setups.{setup_module_name}")
         else:
             sys.path.append(base_setup_path)
             importlib.import_module(setup_module_name)


### PR DESCRIPTION
## Reason for the proposed changes

Currently one gets "no module named d3a_api_client.setups.{setup_module_name}" as this is a reference to the old folder


## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=master
<!--- If needed, choose which gsy-framework branch should be used to build docker image to execute integration tests.-->
**GSY_FRAMEWORK_BRANCH**=master
