### PR TITLE
Fix on_market_slot event

### DIFF
--- a/gsy_e_sdk/clients/rest_asset_client.py
+++ b/gsy_e_sdk/clients/rest_asset_client.py
@@ -18,15 +18,16 @@ from gsy_e_sdk.websocket_device import DeviceWebsocketMessageReceiver
 
 REGISTER_COMMAND_TIMEOUT = 15 * 60
 
-#pylint: disable=too-many-instance-attributes
+
+# pylint: disable-next=too-many-instance-attributes
 class RestAssetClient(APIClientInterface, RestCommunicationMixin):
     """Client class for assets to be used while working with REST."""
 
-    # pylint: disable=super-init-not-called
-    # pylint: disable=too-many-arguments
+    # pylint: disable-next=super-init-not-called
+    # pylint: disable-next=too-many-arguments
     def __init__(
             self, asset_uuid, simulation_id=None, domain_name=None, websockets_domain_name=None,
-             autoregister=False, start_websocket=True, sim_api_domain_name=None):
+            autoregister=False, start_websocket=True, sim_api_domain_name=None):
         self.simulation_id = simulation_id if simulation_id else simulation_id_from_env()
         self.domain_name = domain_name if domain_name else domain_name_from_env()
         self.websockets_domain_name = websockets_domain_name or websocket_domain_name_from_env()

--- a/gsy_e_sdk/clients/rest_asset_client.py
+++ b/gsy_e_sdk/clients/rest_asset_client.py
@@ -157,13 +157,16 @@ class RestAssetClient(APIClientInterface, RestCommunicationMixin):
                                     function=lambda: self.on_finish(message),
                                     function_name="on_finish")
 
-    # pylint: disable=unused-argument
-    def on_market_cycle(self, market_info):
-        """Perform actions that should be triggered on market_cycle event."""
+    def on_market_cycle(self, market_info):  # pylint: disable=unused-argument
+        """(DEPRECATED) Perform actions that should be triggered on market_cycle event.
+
+        This method was deprecated in favor of the new `on_market_slot`.
+        """
         if not self.registered:
             self.register()
 
     def on_market_slot(self, market_info):
+        """Perform actions that should be triggered on market event."""
         self.on_market_cycle(market_info)
 
     def on_tick(self, tick_info):

--- a/gsy_e_sdk/redis_aggregator.py
+++ b/gsy_e_sdk/redis_aggregator.py
@@ -252,8 +252,10 @@ class RedisAggregator:
         self.area_name_uuid_mapping = \
             create_area_name_uuid_mapping_from_tree_info(self.latest_grid_tree_flat)
         self.grid_fee_calculation.handle_grid_stats(self.latest_grid_tree)
-        self.executor.submit(execute_function_util, function=lambda: self.on_market_cycle(message),
-                             function_name="on_market_cycle")
+        self.executor.submit(
+            execute_function_util,
+            function=lambda: self.on_market_slot(message),
+            function_name="on_market_slot")
 
     @buffer_grid_tree_info
     def _on_tick(self, message: Dict) -> None:
@@ -276,10 +278,14 @@ class RedisAggregator:
                              function_name="on_finish")
 
     def on_market_cycle(self, market_info):
-        """Perform actions that should be triggered on market_cycle event."""
+        """(DEPRECATED) Perform actions that should be triggered on market_cycle event.
+
+        This method was deprecated in favor of the new `on_market_slot`.
+        """
 
     def on_market_slot(self, market_info):
-        """Perform actions that should be triggered on market_cycle event."""
+        """Perform actions that should be triggered on market event."""
+        self.on_market_cycle(market_info)
 
     def on_tick(self, tick_info):
         """Perform actions that should be triggered on tick event."""


### PR DESCRIPTION
## Reason for the proposed changes

The `market` event is currently not being used to trigger the `on_market_slot` (nor the old `on_market_cycle`) method when Redis is running. 

## Proposed changes

- Call the new `on_market_slot` method when the `market` event is received.
- Call `on_market_cycle` (old alias for the new `on_market_slot`) when `on_market_slot` is called.

## References

- #228 

---

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=master
<!--- If needed, choose which gsy-framework branch should be used to build docker image to execute integration tests.-->
**GSY_FRAMEWORK_BRANCH**=master
