### PR TITLE
GSYE-364: Fix backports-entry-points-selectable==1.1.0 installation error

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ attrs==21.2.0
     #   jsonschema
 awesome-slugify==1.6.5
     # via -r requirements/base.in
-backports-entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.0
     # via
     #   gsy-framework
     #   virtualenv

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -16,7 +16,7 @@ attrs==21.2.0
     #   pytest
 awesome-slugify==1.6.5
     # via -r requirements/base.txt
-backports-entry-points-selectable==1.1.0
+backports.entry-points-selectable==1.1.0
     # via
     #   -r requirements/base.txt
     #   gsy-framework


### PR DESCRIPTION
## Proposed Changes:
- Fix dependency name for backports-entry-points-selectable

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=bug/GSYE-364
<!--- If needed, choose which gsy-framework branch should be used to build docker image to execute integration tests.-->
**GSY_FRAMEWORK_BRANCH**=bug/GSYE-364
