### PR TITLE
Added the simulation_id as parameter to the Redis channel name, in or…

### DIFF
--- a/gsy_e_sdk/redis_client_base.py
+++ b/gsy_e_sdk/redis_client_base.py
@@ -110,7 +110,11 @@ class RedisClientBase(APIClientInterface):
 
     def _on_register(self, msg):
         message = json.loads(msg["data"])
-        self._check_buffer_message_matching_command_and_id(message)
+        try:
+            self._check_buffer_message_matching_command_and_id(message)
+        except RedisAPIException as exc:
+            logging.debug(f"Ignoring message due to error ({str(exc)}). Message body: {message}")
+            return
         self.area_uuid = message["device_uuid"]
 
         logging.info(f"{self.area_id} was registered")


### PR DESCRIPTION
…der to be able to connect to a simulation using a specific id even when running via Redis. Ignored messages from areas that are not registered to this sdk execution.

## Reason for the proposed changes

Please describe what we want to achieve and why.

## Proposed changes

-

<!--- If needed, choose which branch of the gsy-backend-integration-tests repository will be used to run integration tests. Please only edit the name of the branch. -->
**INTEGRATION_TESTS_BRANCH**=master
<!--- If needed, choose which gsy-e branch should be used to build docker image to execute integration tests.-->
**GSY_E_TARGET_BRANCH**=master
<!--- If needed, choose which gsy-framework branch should be used to build docker image to execute integration tests.-->
**GSY_FRAMEWORK_BRANCH**=master
